### PR TITLE
fix: paymentItem 컴포넌트 수정

### DIFF
--- a/src/components/common/PaymentItem/PaymentItem.vue
+++ b/src/components/common/PaymentItem/PaymentItem.vue
@@ -21,14 +21,17 @@
 <template>
     <li class="d-flex justify-content-between w-100">
         <div class="d-flex gap-2">
-            <Emoji :emoji="convertCategoryToEmoji(props.category)"></Emoji>
-            <div v-if="category" class="title-category-box">
+            <Emoji :emoji="props.emoji"></Emoji>
+            <div v-if="title&&category" class="title-category-box">
                 <BaseTypography size="md" weight="medium" class="title">
                     {{ props.title }}
                 </BaseTypography>
                 <BaseTypography size="sm" weight="medium" color="gray">{{
                     props.category
                 }}</BaseTypography>
+            </div>
+            <div v-else-if="category" size="md" weight="medium" class="title-box">
+                {{ props.category }}
             </div>
             <div v-else class="title-box">
                 <BaseTypography size="lg" weight="bold">
@@ -51,7 +54,6 @@
 import BaseTypography from '../Typography/BaseTypography.vue'
 import Emoji from './Emoji.vue'
 import { computed, defineProps } from 'vue'
-import { convertCategoryToEmoji } from '@/utils/common'
 const props = defineProps({
     title: {
         type: String,
@@ -65,6 +67,9 @@ const props = defineProps({
     transactionType: {
         type: String,
     },
+    emoji:{
+        type:String
+    }
 })
 
 const amountColor = computed(() => {

--- a/src/pages/PaymentsPage.vue
+++ b/src/pages/PaymentsPage.vue
@@ -10,6 +10,7 @@
             :transactionType="payment.transactionType"
         ></PaymentItem>
         <PaymentItem :title="payment.title" :emoji="payment.emoji"></PaymentItem>
+        <PaymentItem :category="payment.category" :emoji="payment.emoji" :amount="payment.amount"></PaymentItem>
     </BaseLayout>
 </template>
 
@@ -22,5 +23,6 @@ const payment = reactive({
     category: '카페',
     amount: 1000,
     transactionType: 'spending',
+    emoji:'🥲'
 })
 </script>

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -20,12 +20,3 @@ export const getRandomColor = () => {
     ]
     return colors[randomNumber]
 }
-
-export const convertCategoryToEmoji = (category) => {
-    switch (category) {
-        case 'q':
-            return '🍕'
-        default:
-            return '🍔'
-    }
-}


### PR DESCRIPTION
## 해결하려는 문제

 - (fix/resolve) KB-16th-Frontend/snap_client#(19)

## 주요 변경 내용 요약

|변경사항 1|` emoji를 props로 전달하도록 변경 ` | 컴포넌트 |
|변경사항 2|` util의 convertCategoryToEmoji 함수 삭제 ` | 코드 |
|변경사항 3|` paymentItem가 다음 3가지 경우를 모두 표현할 수 있게끔 변경. 1. 소비 기록 상세 페이지에서 쓰이는 경우(타이틀&&카테고리) 2. 지출 분석에서 쓰이는 경우(카테고리&&금액) 3. 지출 기록 상세, 지출/수입 기록 추가/변경 완료 페이지에서 쓰이는 경우(타이틀만) ` | 컴포넌트 |

